### PR TITLE
fix: splitting input into tokens

### DIFF
--- a/scanner.erl
+++ b/scanner.erl
@@ -10,6 +10,6 @@ convert_integers(V) ->
 
 scan() ->
   Source = io:get_line("ar>"),
-  Parsed = string:tokens(Source, " "),
+  Parsed = string:lexemes(Source, " " ++ [$\n]),
   lists:map(fun(T) -> convert_integers(T) end, Parsed).
 


### PR DESCRIPTION
Hey Lucas,

What a weird and also awesome language! The code is tricky and blowed my mind. Actually had fun with it, thank you.

## Problem

I cloned the project and figured out - somehow - my way to run it. I followed the example in the README, but failed with the following error:

```bash
ar>calc + 2 2
error: "after operator must be declared the value" 
{"init terminating in do_boot",{badarith,[{erlang,'+',[2,exit],[]},{eval,operate,2,[{file,"eval.erl"},{line,45}]},{main,execute,0,[{file,"main.erl"},{line,13}]},{init,start_em,1,[]},{init,do_boot,3,[]}]}}
init terminating in do_boot ({badarith,[{erlang,+,[2,exit],[]},{eval,operate,2,[{_},{_}]},{main,execute,0,[{_},{_}]},{init,start_em,1,[]},{init,do_boot,3,[]}]})
```

## Expected Behaviour

To type `calc + 2 2` and print `4`.

## Possible Solution

I digged into the code for debugging, and found that I was not typing a space at the end, like `calc + 2 2 `. Without the space, the last string `2` was not recognized as an integer token, but as the string `2\n`.

In order to fix it, just add the end of line `\n` as another separator, as well as the space. I also changed the function from `tokens` to `lexemes` due to deprecation, from [here](https://www.erlang.org/doc/man/string.html#tokens-2).